### PR TITLE
Add customizable profiles and tone settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Prompt Perfect Clone
+
+This repository contains a small clone of a prompt optimization tool inspired by the Prompt Perfect extension. The script provides a command-line interface to rewrite a user prompt with additional instructions aimed at producing better responses from language models. The new version supports custom instruction profiles and different response tones.
+
+## Usage
+
+Run the script with a prompt as an argument:
+
+```bash
+python3 main.py "Write a short story about space exploration"
+```
+
+If no prompt is provided on the command line, the script will ask for it interactively.
+
+You can choose a response tone or load a custom instruction profile:
+
+```bash
+python3 main.py "Summarise the plot of Hamlet" --tone creative
+python3 main.py "Explain quantum computing" --profile profile_example.json --output-file optimized.txt
+```
+
+`profile_example.json` shows how you can define your own base instructions and
+tone-specific guidance.
+
+## Output Example
+
+```
+$ python3 main.py "Write a poem about the ocean" --tone creative
+Please respond to the following prompt with a detailed and well-structured answer.
+Prompt: Write a poem about the ocean.
+
+Instructions for the response:
+- Use clear and concise language
+- Provide examples when relevant
+- Structure the response in short paragraphs
+- Feel free to use expressive language and imagery.
+- Incorporate metaphors or analogies where appropriate.
+```
+
+The script has no external dependencies and should work with any Python 3 installation.

--- a/main.py
+++ b/main.py
@@ -1,1 +1,96 @@
-print("Hello from Codex!")
+
+"""A small command-line tool to optimize prompts for large language models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict, Iterable, List
+
+
+DEFAULT_PROFILE: Dict[str, object] = {
+    "base_instructions": [
+        "Use clear and concise language",
+        "Provide examples when relevant",
+        "Structure the response in short paragraphs",
+    ],
+    "tone_specific": {
+        "formal": ["Maintain a professional tone."],
+        "creative": [
+            "Feel free to use expressive language and imagery.",
+            "Incorporate metaphors or analogies where appropriate.",
+        ],
+        "informal": ["Write in a friendly and conversational style."],
+    },
+}
+
+
+class PromptOptimizer:
+    """Optimize prompts using configurable instruction profiles."""
+
+    def __init__(self, profile: Dict[str, object] | None = None) -> None:
+        self.profile = profile or DEFAULT_PROFILE
+
+    @classmethod
+    def from_file(cls, path: str) -> "PromptOptimizer":
+        """Load a profile from a JSON file."""
+        with open(path, "r", encoding="utf-8") as fh:
+            profile = json.load(fh)
+        return cls(profile)
+
+    def _gather_instructions(self, tone: str) -> Iterable[str]:
+        base: List[str] = self.profile.get("base_instructions", [])
+        tone_map: Dict[str, List[str]] = self.profile.get("tone_specific", {})
+        return list(base) + tone_map.get(tone, [])
+
+    def optimize(self, prompt: str, tone: str = "formal") -> str:
+        base_prompt = prompt.strip().rstrip(".?!")
+        instructions = "\n- ".join(self._gather_instructions(tone))
+        return (
+            "Please respond to the following prompt with a detailed and well-structured answer.\n"
+            f"Prompt: {base_prompt}.\n\nInstructions for the response:\n- {instructions}"
+        )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Optimize prompts for LLMs")
+    parser.add_argument("prompt", nargs="?", help="Prompt text. If omitted, read from stdin")
+    parser.add_argument(
+        "--tone",
+        choices=["formal", "creative", "informal"],
+        default="formal",
+        help="Instruction style to apply",
+    )
+    parser.add_argument(
+        "--profile",
+        help="Path to JSON file with instruction profile",
+    )
+    parser.add_argument(
+        "--output-file",
+        help="Write the optimized prompt to this file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    prompt_text = args.prompt
+    if prompt_text is None:
+        prompt_text = input("Enter a prompt: ")
+
+    optimizer = (
+        PromptOptimizer.from_file(args.profile) if args.profile else PromptOptimizer()
+    )
+    optimized = optimizer.optimize(prompt_text, tone=args.tone)
+
+    if args.output_file:
+        with open(args.output_file, "w", encoding="utf-8") as fh:
+            fh.write(optimized)
+    else:
+        print(optimized)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py.txt
+++ b/main.py.txt
@@ -1,1 +1,0 @@
-print("Hello from Codex!")

--- a/profile_example.json
+++ b/profile_example.json
@@ -1,0 +1,11 @@
+{
+    "base_instructions": [
+        "Answer in bullet points",
+        "Keep responses under 150 words"
+    ],
+    "tone_specific": {
+        "formal": ["Use professional language."],
+        "creative": ["Include imaginative comparisons."],
+        "informal": ["Feel free to use colloquial expressions."]
+    }
+}


### PR DESCRIPTION
## Summary
- overhaul CLI to support instruction profiles and tone selection
- document new options and add a `profile_example.json`
- remove obsolete `main.py.txt`

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py "Write about AI" --tone informal`
- `python3 main.py "Explain relativity" --profile profile_example.json --tone creative`


------
https://chatgpt.com/codex/tasks/task_b_684535ccfdac83248bad1b842846391f